### PR TITLE
Fix "cannot call non-const fn in constant functions" compile error

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,6 +1,6 @@
 use super::*;
 use flume::{bounded, unbounded, Sender};
-use parking_lot::{lock_api::RawRwLock, RwLock};
+use parking_lot::RwLock;
 use Payload::*;
 
 static TX: StaticTx = StaticTx::none();
@@ -115,7 +115,7 @@ pub struct StaticTx(RwLock<Option<Sender<Payload>>>);
 
 impl StaticTx {
     const fn none() -> Self {
-        StaticTx(RwLock::const_new(parking_lot::RawRwLock::INIT, None))
+        StaticTx(parking_lot::const_rwlock(None))
     }
 
     fn set_tx(&self, tx: Sender<Payload>) {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,6 +1,6 @@
 use super::*;
 use flume::{bounded, unbounded, Sender};
-use parking_lot::RwLock;
+use parking_lot::{lock_api::RawRwLock, RwLock};
 use Payload::*;
 
 static TX: StaticTx = StaticTx::none();
@@ -115,7 +115,7 @@ pub struct StaticTx(RwLock<Option<Sender<Payload>>>);
 
 impl StaticTx {
     const fn none() -> Self {
-        StaticTx(RwLock::const_new(None))
+        StaticTx(RwLock::const_new(parking_lot::RawRwLock::INIT, None))
     }
 
     fn set_tx(&self, tx: Sender<Payload>) {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -115,7 +115,7 @@ pub struct StaticTx(RwLock<Option<Sender<Payload>>>);
 
 impl StaticTx {
     const fn none() -> Self {
-        StaticTx(RwLock::new(None))
+        StaticTx(RwLock::const_new(None))
     }
 
     fn set_tx(&self, tx: Sender<Payload>) {


### PR DESCRIPTION
When I try to compile `howudoin` on stable Rust (1.67.1), I get the following compile error:
```
   Compiling howudoin v0.1.1
error[E0015]: cannot call non-const fn `parking_lot::lock_api::RwLock::<parking_lot::RawRwLock, Option<flume::Sender<Payload>>>::new` in constant functions
   --> /home/dev/.cargo/registry/src/github.com-1ecc6299db9ec823/howudoin-0.1.1/src/tx.rs:118:18
    |
118 |         StaticTx(RwLock::new(None))
    |                  ^^^^^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
```

I think the fix is to call the `const_new()` function instead:
https://docs.rs/lock_api/0.4.6/lock_api/struct.RwLock.html#method.const_new