### PR TITLE
Add required features for each example to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,14 @@ parking_lot = "0.12"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
+[[example]]
+name = "term-line"
+required-features = ["term-line"]
+
+[[example]]
+name = "json-printer"
+required-features = ["json-printer"]
+
 # docs.rs-specific configuration
 [package.metadata.docs.rs]
 # document all features


### PR DESCRIPTION
When I run `cargo test`, I get compilation errors in the examples:
```
   Compiling howudoin v0.1.1 (/home/dev/how-u-doin)                                                                                                                                                        
error[E0433]: failed to resolve: could not find `TermLine` in `consumers`                                                                                                                                  
 --> examples/term-line.rs:8:41                                                                                                                                                                            
  |                                                                                                                                                                                                        
8 |     howudoin::init(howudoin::consumers::TermLine::new());                                                                                                                                              
  |                                         ^^^^^^^^ could not find `TermLine` in `consumers`                                                                                                              
                                                                                                                                                                                                           
error[E0433]: failed to resolve: could not find `JsonPrinter` in `consumers`                                                                                                                               
 --> examples/json-printer.rs:5:41                                                                                                                                                                         
  |                                                                                                                                                                                                        
5 |     howudoin::init(howudoin::consumers::JsonPrinter::default());                                                                                                                                       
  |                                         ^^^^^^^^^^^ could not find `JsonPrinter` in `consumers`                                                                                                        
                                                                                                     
For more information about this error, try `rustc --explain E0433`.                                                                                                                                        
...
```

This fix adds the features needed for each example to Cargo.toml.
