### PR TITLE
feat: use Option for InProgress::remaining

### DIFF
--- a/examples/consume-impl.rs
+++ b/examples/consume-impl.rs
@@ -22,6 +22,7 @@ impl Consume for SimplePrinter {
                 remaining,
             } => {
                 let done = *pos as f32 / len.unwrap_or(0) as f32 * 100.;
+                let remaining = remaining.unwrap_or(f32::INFINITY);
                 println!("{done:.1}% - eta {remaining}s");
             }
             State::Completed { duration } => {

--- a/src/report.rs
+++ b/src/report.rs
@@ -67,7 +67,7 @@ pub enum State {
         bytes: bool,
 
         /// **Seconds** remaining.
-        remaining: f32,
+        remaining: Option<f32>,
     },
     /// The progress reporter is finished.
     ///
@@ -88,7 +88,7 @@ impl Default for State {
             len: None,
             pos: 0,
             bytes: false,
-            remaining: f32::INFINITY,
+            remaining: None,
         }
     }
 }

--- a/src/rx.rs
+++ b/src/rx.rs
@@ -296,7 +296,7 @@ impl Report {
 
             if let Some(len) = *len {
                 let rate = elapsed.as_secs_f32() / *pos as f32;
-                *remaining = (len - *pos) as f32 * rate;
+                *remaining = Some((len - *pos) as f32 * rate);
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ fn reset_rems(xs: Vec<Progress>) -> Vec<Progress> {
     xs.into_iter()
         .map(|mut x| {
             match &mut x.report.state {
-                State::InProgress { remaining, .. } => *remaining = 1.,
+                State::InProgress { remaining, .. } => *remaining = Some(1.),
                 State::Completed { duration } => *duration = 1.,
                 _ => (),
             }
@@ -48,7 +48,7 @@ fn report_creation_smoke_test() {
                         len: None,
                         pos: 0,
                         bytes: false,
-                        remaining: f32::INFINITY,
+                        remaining: None,
                     },
                     accums: vec![]
                 },
@@ -61,7 +61,7 @@ fn report_creation_smoke_test() {
                                 len: None,
                                 pos: 0,
                                 bytes: false,
-                                remaining: f32::INFINITY,
+                                remaining: None,
                             },
                             accums: vec![]
                         },
@@ -75,7 +75,7 @@ fn report_creation_smoke_test() {
                                 len: None,
                                 pos: 0,
                                 bytes: false,
-                                remaining: f32::INFINITY,
+                                remaining: None,
                             },
                             accums: vec![]
                         },
@@ -91,7 +91,7 @@ fn report_creation_smoke_test() {
                         len: None,
                         pos: 0,
                         bytes: false,
-                        remaining: f32::INFINITY
+                        remaining: None,
                     },
                     accums: vec![]
                 },
@@ -122,7 +122,7 @@ fn tx_api() {
                     len: Some(100),
                     pos: 6,
                     bytes: true,
-                    remaining: 1.
+                    remaining: Some(1.)
                 },
                 accums: vec![Message {
                     severity: Severity::Error,
@@ -146,7 +146,7 @@ fn tx_api() {
                     len: Some(100),
                     pos: 50,
                     bytes: true,
-                    remaining: 1.
+                    remaining: Some(1.)
                 },
                 accums: vec![
                     Message {


### PR DESCRIPTION
InProgress::remaining defaults to f32::INFINITY which is problematic to work with because it's not serializable in JSON.

Use Option for the remaining field, and None as the default value signaling that we *don't know* the remaining time.